### PR TITLE
fix: install Swift directly into `/usr/...` directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           INSTALL_DIRECTORY: ${{ steps.install_swift.outputs.install_directory }}
           LD_LIBRARY_DIRECTORY: ${{ steps.install_swift.outputs.ld_library_directory }}
         run: |
-          [[ "${INSTALL_DIRECTORY}" == "${HOME}/swift-5.8-RELEASE-ubuntu22.04" ]] || \
+          [[ "${INSTALL_DIRECTORY}" == "${HOME}/swift-6.0.2-RELEASE-ubuntu22.04" ]] || \
             (echo >&2 "Unexpected install directory. ${INSTALL_DIRECTORY}" && exit 1)
           [[ "${LD_LIBRARY_DIRECTORY}" == "${INSTALL_DIRECTORY}/usr/lib/swift/linux" ]] || \
             (echo >&2 "Unexpected install directory. ${LD_LIBRARY_DIRECTORY}" && exit 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,17 @@ jobs:
         with:
           swift_release_tag: "swift-6.0.2-RELEASE"
           ubuntu_version: "22.04"
-      # DEBUG BEGIN
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-      # DEBUG END
+      # # DEBUG BEGIN
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3
+      # # DEBUG END
       - name: Verify Installation
         shell: bash
         env:
-          INSTALL_DIRECTORY: ${{ steps.install_swift.outputs.install_directory }}
           LD_LIBRARY_DIRECTORY: ${{ steps.install_swift.outputs.ld_library_directory }}
         run: |
           # Verify version is correct
-          swift --version | grep "Apple Swift version 6.0.2"
+          swift --version | grep "Swift version 6.0.2"
           # Verify the LD_LIBRARY_DIRECTORY output is correct.
           [[ "${LD_LIBRARY_DIRECTORY}" == "/usr/lib/swift/linux" ]] || \
             (echo >&2 "Unexpected install directory. ${LD_LIBRARY_DIRECTORY}" && exit 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         name: Install Swift
         id: install_swift
         with:
-          swift_release_tag: "swift-5.8-RELEASE"
+          swift_release_tag: "swift-6.0.2-RELEASE"
           ubuntu_version: "22.04"
       - name: Verify Installation
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,11 @@ jobs:
           INSTALL_DIRECTORY: ${{ steps.install_swift.outputs.install_directory }}
           LD_LIBRARY_DIRECTORY: ${{ steps.install_swift.outputs.ld_library_directory }}
         run: |
-          [[ "${INSTALL_DIRECTORY}" == "${HOME}/swift-6.0.2-RELEASE-ubuntu22.04" ]] || \
-            (echo >&2 "Unexpected install directory. ${INSTALL_DIRECTORY}" && exit 1)
-          [[ "${LD_LIBRARY_DIRECTORY}" == "${INSTALL_DIRECTORY}/usr/lib/swift/linux" ]] || \
+          # Verify version is correct
+          swift --version | grep "Apple Swift version 6.0.2"
+          # Verify the LD_LIBRARY_DIRECTORY output is correct.
+          [[ "${LD_LIBRARY_DIRECTORY}" == "/usr/lib/swift/linux" ]] || \
             (echo >&2 "Unexpected install directory. ${LD_LIBRARY_DIRECTORY}" && exit 1)
-          # Verify that installed version is found in PATH
-          swift_path="$(which swift)"
-          [[ "${swift_path}" =~ "${INSTALL_DIRECTORY}" ]] || \
-            (echo >&2 "Unexpected swift path. ${swift_path}" && exit 1)
           # Verify that LD_LIBRARY_PATH has been updated
           [[ "${LD_LIBRARY_PATH}" =~ "${LD_LIBRARY_DIRECTORY}" ]] || \
             (echo >&2 "Did not find LD_LIBRARY_DIRECTORY in LD_LIBRARY_PATH. ${LD_LIBRARY_PATH}" && exit 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,6 @@ jobs:
         with:
           swift_release_tag: "swift-6.0.2-RELEASE"
           ubuntu_version: "22.04"
-      # # DEBUG BEGIN
-      # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
-      # # DEBUG END
       - name: Verify Installation
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ jobs:
         with:
           swift_release_tag: "swift-6.0.2-RELEASE"
           ubuntu_version: "22.04"
+      # DEBUG BEGIN
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+      # DEBUG END
       - name: Verify Installation
         shell: bash
         env:

--- a/action.yml
+++ b/action.yml
@@ -25,8 +25,6 @@ runs:
         # Variables
         distro_dirname="ubuntu${UBUNTU_VERSION/[.]/}"
         install_dirname="${SWIFT_RELEASE_TAG}-ubuntu${UBUNTU_VERSION}"
-        # install_directory="${HOME}/${install_dirname}"
-        # ld_library_directory="${install_directory}/usr/lib/swift/linux"
         ld_library_directory="/usr/lib/swift/linux"
         archive_filename="${install_dirname}.tar.gz"
         lowercase_swift_release_tag="$( echo "${SWIFT_RELEASE_TAG}" | tr '[:upper:]' '[:lower:]')"
@@ -39,24 +37,3 @@ runs:
         echo "LD_LIBRARY_PATH=${ld_library_directory}:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
         # Output the value that should be added to the LD_LIBRARY_PATH env variable.
         echo "ld_library_directory=${ld_library_directory}" >> $GITHUB_OUTPUT
-
-      # run: |
-      #   # Variables
-      #   distro_dirname="ubuntu${UBUNTU_VERSION/[.]/}"
-      #   install_dirname="${SWIFT_RELEASE_TAG}-ubuntu${UBUNTU_VERSION}"
-      #   install_directory="${HOME}/${install_dirname}"
-      #   ld_library_directory="${install_directory}/usr/lib/swift/linux"
-      #   archive_filename="${install_dirname}.tar.gz"
-      #   lowercase_swift_release_tag="$( echo "${SWIFT_RELEASE_TAG}" | tr '[:upper:]' '[:lower:]')"
-      #   archive_url="https://download.swift.org/${lowercase_swift_release_tag}/${distro_dirname}/${SWIFT_RELEASE_TAG}/${archive_filename}"
-      #   # Download and expand the release archive
-      #   wget "${archive_url}"
-      #   tar -xvzf "${archive_filename}" -C "${HOME}"
-      #   # Add the usr/bin Swift install directory to the PATH for later actions
-      #   echo "${install_directory}/usr/bin" >> "${GITHUB_PATH}"
-      #   # Update LD_LIBRARY_PATH
-      #   echo "LD_LIBRARY_PATH=${ld_library_directory}:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
-      #   # Output the install directory
-      #   echo "install_directory=${install_directory}" >> $GITHUB_OUTPUT
-      #   # Output the value that should be added to the LD_LIBRARY_PATH env variable.
-      #   echo "ld_library_directory=${ld_library_directory}" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
 
         # Download and expand the release archive
         wget "${archive_url}"
-        tar --strip-components 1 -xvzf "${archive_filename}" -C /
+        sudo tar --strip-components 1 -xvzf "${archive_filename}" -C /
         # Update LD_LIBRARY_PATH
         echo "LD_LIBRARY_PATH=${ld_library_directory}:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
         # Output the install directory

--- a/action.yml
+++ b/action.yml
@@ -33,14 +33,34 @@ runs:
         archive_filename="${install_dirname}.tar.gz"
         lowercase_swift_release_tag="$( echo "${SWIFT_RELEASE_TAG}" | tr '[:upper:]' '[:lower:]')"
         archive_url="https://download.swift.org/${lowercase_swift_release_tag}/${distro_dirname}/${SWIFT_RELEASE_TAG}/${archive_filename}"
+
         # Download and expand the release archive
         wget "${archive_url}"
-        tar -xvzf "${archive_filename}" -C "${HOME}"
-        # Add the usr/bin Swift install directory to the PATH for later actions
-        echo "${install_directory}/usr/bin" >> "${GITHUB_PATH}"
+        tar --strip-components 1 -xvzf "${archive_filename}" -C /
         # Update LD_LIBRARY_PATH
         echo "LD_LIBRARY_PATH=${ld_library_directory}:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
         # Output the install directory
         echo "install_directory=${install_directory}" >> $GITHUB_OUTPUT
         # Output the value that should be added to the LD_LIBRARY_PATH env variable.
         echo "ld_library_directory=${ld_library_directory}" >> $GITHUB_OUTPUT
+
+      # run: |
+      #   # Variables
+      #   distro_dirname="ubuntu${UBUNTU_VERSION/[.]/}"
+      #   install_dirname="${SWIFT_RELEASE_TAG}-ubuntu${UBUNTU_VERSION}"
+      #   install_directory="${HOME}/${install_dirname}"
+      #   ld_library_directory="${install_directory}/usr/lib/swift/linux"
+      #   archive_filename="${install_dirname}.tar.gz"
+      #   lowercase_swift_release_tag="$( echo "${SWIFT_RELEASE_TAG}" | tr '[:upper:]' '[:lower:]')"
+      #   archive_url="https://download.swift.org/${lowercase_swift_release_tag}/${distro_dirname}/${SWIFT_RELEASE_TAG}/${archive_filename}"
+      #   # Download and expand the release archive
+      #   wget "${archive_url}"
+      #   tar -xvzf "${archive_filename}" -C "${HOME}"
+      #   # Add the usr/bin Swift install directory to the PATH for later actions
+      #   echo "${install_directory}/usr/bin" >> "${GITHUB_PATH}"
+      #   # Update LD_LIBRARY_PATH
+      #   echo "LD_LIBRARY_PATH=${ld_library_directory}:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+      #   # Output the install directory
+      #   echo "install_directory=${install_directory}" >> $GITHUB_OUTPUT
+      #   # Output the value that should be added to the LD_LIBRARY_PATH env variable.
+      #   echo "ld_library_directory=${ld_library_directory}" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,6 @@ inputs:
     default: "22.04"
 
 outputs:
-  install_directory:
-    description: The install directory.
-    value: ${{ steps.install_swift.outputs.install_directory }}
   ld_library_directory:
     description: The directory that contains the shared libraries.
     value: ${{ steps.install_swift.outputs.ld_library_directory }}
@@ -28,8 +25,9 @@ runs:
         # Variables
         distro_dirname="ubuntu${UBUNTU_VERSION/[.]/}"
         install_dirname="${SWIFT_RELEASE_TAG}-ubuntu${UBUNTU_VERSION}"
-        install_directory="${HOME}/${install_dirname}"
-        ld_library_directory="${install_directory}/usr/lib/swift/linux"
+        # install_directory="${HOME}/${install_dirname}"
+        # ld_library_directory="${install_directory}/usr/lib/swift/linux"
+        ld_library_directory="/usr/lib/swift/linux"
         archive_filename="${install_dirname}.tar.gz"
         lowercase_swift_release_tag="$( echo "${SWIFT_RELEASE_TAG}" | tr '[:upper:]' '[:lower:]')"
         archive_url="https://download.swift.org/${lowercase_swift_release_tag}/${distro_dirname}/${SWIFT_RELEASE_TAG}/${archive_filename}"
@@ -39,8 +37,6 @@ runs:
         sudo tar --strip-components 1 -xvzf "${archive_filename}" -C /
         # Update LD_LIBRARY_PATH
         echo "LD_LIBRARY_PATH=${ld_library_directory}:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
-        # Output the install directory
-        echo "install_directory=${install_directory}" >> $GITHUB_OUTPUT
         # Output the value that should be added to the LD_LIBRARY_PATH env variable.
         echo "ld_library_directory=${ld_library_directory}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Fixes environment issues where `rules_swift` cannot find tools and libraries. This PR extracts the Swift release directly at the root so that the files are installed in the correct relative locations.

Example error from `swift_gazelle`:

```
ERROR: /home/runner/.cache/bazel/_bazel_runner/08c09e7a19e19539e62b43fedc1de0bf/execroot/_main/_tmp/08064f0f577f53d95a538231379cf553/_bazel_runner/1b421e3546754bda19fc266f5472ac76/external/rules_swift_package_manager~~swift_deps~swiftpkg_swift_argument_parser/BUILD.bazel:172:14: Extracting autolink data for Swift module @@rules_swift_package_manager~~swift_deps~swiftpkg_swift_argument_parser//:ArgumentParserToolInfo.rspm failed: (Exit 2): worker failed: error executing SwiftAutolinkExtract command (from target @@rules_swift_package_manager~~swift_deps~swiftpkg_swift_argument_parser//:ArgumentParserToolInfo.rspm) 
  (cd /home/runner/.cache/bazel/_bazel_runner/08c09e7a19e19539e62b43fedc1de0bf/execroot/_main/_tmp/08064f0f577f53d95a538231379cf553/_bazel_runner/1b421e3546754bda19fc266f5472ac76/sandbox/linux-sandbox/160/execroot/_main && \
  exec env - \
    PATH=/bin:/usr/bin:/usr/local/bin \
  bazel-out/k8-opt-exec-ST-d57f47055a04/bin/external/rules_swift~/tools/worker/worker /usr/local/bin/swift-autolink-extract '-Xwrapped-swift=-bazel-target-label=@@rules_swift_package_manager~~swift_deps~swiftpkg_swift_argument_parser//:ArgumentParserToolInfo.rspm' bazel-out/k8-fastbuild/bin/external/rules_swift_package_manager~~swift_deps~swiftpkg_swift_argument_parser/ArgumentParserToolInfo.rspm_objs/Sources/ArgumentParserToolInfo/ToolInfo.swift.o -o bazel-out/k8-fastbuild/bin/external/rules_swift_package_manager~~swift_deps~swiftpkg_swift_argument_parser/ArgumentParserToolInfo.rspm.autolink)
# Configuration: abf22e7[260](https://github.com/cgrindel/swift_gazelle_plugin/actions/runs/12097806181/job/33733591145#step:6:262)9578480c595c920942e7564c7d9801b9756c10956a7da063b87278
# Execution platform: @@platforms//host:host

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
error: forking process failed '/usr/local/bin/swift-autolink-extract'. No such file or directory
INFO: Elapsed time: 10.454s, Critical Path: 8.93s
INFO: 124 processes: 90 internal, 30 linux-sandbox, 4 worker.
ERROR: Build did NOT complete successfully
```